### PR TITLE
added parent directory functionality

### DIFF
--- a/captain
+++ b/captain
@@ -100,7 +100,7 @@ function list {
 		for file in ${files[@]}; do
 			path=$(dirname $file)
 			project=${path##*/}
-			echo -e "$project | $path"
+		    echo -e "$project ($path)"
 		done
 	done
 }
@@ -115,22 +115,20 @@ function captain {
 
 	for depth in $(seq 1 $MAX_DEPTH); do
 		# Search for docker compose files.
-		check=()
 		files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
 		debug "Found ${#files[@]} projects at depth $depth"
 
 		for file in ${files[@]}; do
 			path=$(dirname $file)
-			project=${path##*/}
-
-			if [[ " ${check[@]} " =~ " $project " ]]; then
-				project=$(basename $(dirname $path))
-			else
-				check+=($project)
-			fi
 		
-			# See if this project matches what we are searching for.
-			if [[ $project == *"$SEARCH"* ]]; then
+			# See if this project matches what we are searching for. 
+			if [[ $path == *"$SEARCH"* ]]; then
+				for dir in ${path////$'\n'}; do
+					if [[ $dir == *"$SEARCH"* ]]; then
+						project=$dir
+					fi
+				done
+
 				debug "Matched $SEARCH with $project"
 				cd $path
 

--- a/captain
+++ b/captain
@@ -96,7 +96,6 @@ function list {
     for depth in $(seq 1 $MAX_DEPTH); do
     # Search for docker compose files.
     files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
-    check=()
 
     for file in ${files[@]}; do
       path=$(dirname $file)

--- a/captain
+++ b/captain
@@ -94,53 +94,61 @@ function update {
 # @info:	List docker projects
 function list {
     for depth in $(seq 1 $MAX_DEPTH); do
-		# Search for docker compose files.
-		files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
+    # Search for docker compose files.
+    files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
+    check=()
 
-		for file in ${files[@]}; do
-			path=$(dirname $file)
-			echo ${path##*/}
-		done
-	done
+    for file in ${files[@]}; do
+      path=$(dirname $file)
+      project=${path##*/}
+      echo -e "$project | $path"
+    done
+  done
 }
 
 # @info:	Main captain function
 function captain {
-	if [[ ! $SEARCH ]]; then
-		usage; exit 1
-	fi
+  if [[ ! $SEARCH ]]; then
+    usage; exit 1
+  fi
 
-	debug "Searching for projects in $FOLDER"
+  debug "Searching for projects in $FOLDER"
 
-	for depth in $(seq 1 $MAX_DEPTH); do
-		# Search for docker compose files.
-		files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
-		debug "Found ${#files[@]} projects at depth $depth"
+  for depth in $(seq 1 $MAX_DEPTH); do
+    # Search for docker compose files.
+    files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
+    debug "Found ${#files[@]} projects at depth $depth"
+    check=()
 
-		for file in ${files[@]}; do
-			path=$(dirname $file)
-			project=${path##*/}
+    for file in ${files[@]}; do
+      path=$(dirname $file)
+      project=${path##*/}
 
-			# See if this project matches what we are searching for.
-			if [[ $project == *"$SEARCH"* ]]; then
-				debug "Matched $SEARCH with $project"
-				cd $path
+      if [[ " ${check[@]} " =~ " $project " ]]; then
+        project=$(basename $(dirname $path))
+      else
+        check+=($project)
+      fi
+      # See if this project matches what we are searching for.
+      if [[ $project == *"$SEARCH"* ]]; then
+        debug "Matched $SEARCH with $project"
+        cd $path
 
-				case $MODE in
-					start )
-						echo "Starting project $project ..."
-						echo
-						docker-compose up -d ;;
-					stop )
-						echo "Stopping project $project ..."
-						echo
-						docker-compose stop ;;
-				esac
+        case $MODE in
+          start )
+            echo "Starting project $project ..."
+            echo
+            docker-compose up -d ;;
+          stop )
+            echo "Stopping project $project ..."
+            echo
+            docker-compose stop ;;
+        esac
 
-				exit 0
-			fi
-		done
-	done
+        exit 0
+      fi
+    done
+  done
 }
 
 check

--- a/captain
+++ b/captain
@@ -94,60 +94,60 @@ function update {
 # @info:	List docker projects
 function list {
     for depth in $(seq 1 $MAX_DEPTH); do
-    # Search for docker compose files.
-    files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
+		# Search for docker compose files.
+		files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
 
-    for file in ${files[@]}; do
-      path=$(dirname $file)
-      project=${path##*/}
-      echo -e "$project | $path"
-    done
-  done
+		for file in ${files[@]}; do
+			path=$(dirname $file)
+			project=${path##*/}
+			echo -e "$project | $path"
+		done
+	done
 }
 
 # @info:	Main captain function
 function captain {
-  if [[ ! $SEARCH ]]; then
-    usage; exit 1
-  fi
+	if [[ ! $SEARCH ]]; then
+		usage; exit 1
+	fi
 
-  debug "Searching for projects in $FOLDER"
+	debug "Searching for projects in $FOLDER"
 
-  for depth in $(seq 1 $MAX_DEPTH); do
-    # Search for docker compose files.
-	check=()
-    files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
-    debug "Found ${#files[@]} projects at depth $depth"
+	for depth in $(seq 1 $MAX_DEPTH); do
+		# Search for docker compose files.
+		check=()
+		files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
+		debug "Found ${#files[@]} projects at depth $depth"
 
-    for file in ${files[@]}; do
-      path=$(dirname $file)
-      project=${path##*/}
+		for file in ${files[@]}; do
+			path=$(dirname $file)
+			project=${path##*/}
 
-      if [[ " ${check[@]} " =~ " $project " ]]; then
-        project=$(basename $(dirname $path))
-      else
-        check+=($project)
-      fi
-      # See if this project matches what we are searching for.
-      if [[ $project == *"$SEARCH"* ]]; then
-        debug "Matched $SEARCH with $project"
-        cd $path
+			if [[ " ${check[@]} " =~ " $project " ]]; then
+				project=$(basename $(dirname $path))
+			else
+				check+=($project)
+			fi
+		
+			# See if this project matches what we are searching for.
+			if [[ $project == *"$SEARCH"* ]]; then
+				debug "Matched $SEARCH with $project"
+				cd $path
 
-        case $MODE in
-          start )
-            echo "Starting project $project ..."
-            echo
-            docker-compose up -d ;;
-          stop )
-            echo "Stopping project $project ..."
-            echo
-            docker-compose stop ;;
-        esac
-
-        exit 0
-      fi
-    done
-  done
+				case $MODE in
+					start )
+						echo "Starting project $project ..."
+						echo
+						docker-compose up -d ;;
+					stop )
+						echo "Stopping project $project ..."
+						echo
+						docker-compose stop ;;
+				esac
+				exit 0
+			fi
+		done
+	done
 }
 
 check

--- a/captain
+++ b/captain
@@ -120,7 +120,8 @@ function captain {
 
 		for file in ${files[@]}; do
 			path=$(dirname $file)
-		
+			project=${path##*/}
+
 			# See if this project matches what we are searching for. 
 			if [[ $path == *"$SEARCH"* ]]; then
 				for dir in ${path////$'\n'}; do

--- a/captain
+++ b/captain
@@ -100,7 +100,7 @@ function list {
 		for file in ${files[@]}; do
 			path=$(dirname $file)
 			project=${path##*/}
-		    echo -e "$project ($path)"
+			echo -e "$project ($path)"
 		done
 	done
 }

--- a/captain
+++ b/captain
@@ -144,6 +144,7 @@ function captain {
 						echo
 						docker-compose stop ;;
 				esac
+
 				exit 0
 			fi
 		done

--- a/captain
+++ b/captain
@@ -115,9 +115,9 @@ function captain {
 
   for depth in $(seq 1 $MAX_DEPTH); do
     # Search for docker compose files.
+	check=()
     files=(`find $FOLDER -maxdepth $depth -mindepth $depth -type f -name docker-compose.yml`)
     debug "Found ${#files[@]} projects at depth $depth"
-    check=()
 
     for file in ${files[@]}; do
       path=$(dirname $file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,0 @@
-redis:
-  image: "redis"
-  container_name : "redis"
-  ports:
-    - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+redis:
+  image: "redis"
+  container_name : "redis"
+  ports:
+    - "6379:6379"


### PR DESCRIPTION
# Use case
Multiple _microservice_ directories containing a dedicated `docker` folder which contains the project's docker info including `docker-compose.yml`.

# Current behaviour
`captain` returns all the projects with the same name making it impossible to start separate projects.

# New behaviour
`captain` takes the parent directory into account, allowing the user to also start the project using the parent directory name (or a part of it).

![](https://i.gyazo.com/057884137c8c2e8ce44dece1d3ed844b.gif)