### PR TITLE
Switch from glide to Go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PWD=$(shell pwd)
 
 build:
-	docker run -it --init --rm -v $(PWD):/code -w /code instrumentisto/glide install
+	docker run -it --init --rm -v $(PWD):/go/src/captain -w /go/src/captain golang go mod tidy
 	docker run -it --init --rm -v $(PWD):/go/src/captain -e GOPATH=/go -w /go/src/captain -e GOOS=darwin golang go build -o dist/captain-osx
 	docker run -it --init --rm -v $(PWD):/go/src/captain -e GOPATH=/go -w /go/src/captain -e GOOS=linux golang go build -o dist/captain-linux
 	docker run -it --init --rm -v $(PWD):/go/src/captain -e GOPATH=/go -w /go/src/captain -e GOOS=windows golang go build -o dist/captain.exe

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,0 @@
-hash: 19a0e5c384b74c03660fa5ffce63781dbb06fecd9748913bcd0011d23c58d531
-updated: 2018-07-11T18:38:33.6003639Z
-imports:
-- name: github.com/sahilm/fuzzy
-  version: df93d96a0fd86b97655b90f63c70802b4e793afb
-- name: github.com/urfave/cli
-  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
-testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,0 @@
-package: github.com/jenssegers/captain
-import:
-- package: github.com/urfave/cli
-  version: ^1.20.0
-- package: github.com/sahilm/fuzzy
-  version: ^0.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/jenssegers/captain
+
+go 1.19
+
+require (
+	github.com/sahilm/fuzzy v0.0.5
+	github.com/urfave/cli v1.20.0
+)
+
+require github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/sahilm/fuzzy v0.0.5 h1:uoWLL/0XKbIlqueDz29CBkFTKmv8vJedcKkZpYB0tz8=
+github.com/sahilm/fuzzy v0.0.5/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
As there's no official Darwin ARM64 build, I decided to build one myself but having to use Glid was a bit of a challenge. My understanding is that it's no longer relevant in light of the Go modules. The [container image](https://github.com/instrumentisto/glide-docker-image) used for running Glide is no longer maintained.