### PR TITLE
Sort projects to make fuzzy-find more predictable

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,21 +107,22 @@ func projects() []Project {
 	wg.Add(1)
 	go scan(&wg, config.Root, config.Depth, channel)
 
-	// Turn channel into slice.
-	projects := []Project{}
 	go func() {
-		for project := range channel {
-			projects = append(projects, project)
-		}
+		wg.Wait()
+		close(channel)
 	}()
 
-	wg.Wait()
+	// Turn channel into slice.
+	var results []Project
+	for project := range channel {
+		results = append(results, project)
+	}
 
-	sort.Slice(projects, func(i, j int) bool {
-		return projects[i].Name < projects[j].Name
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
 	})
 
-	return projects
+	return results
 }
 
 func match(projects []Project, pattern string) (Project, error) {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -115,6 +116,10 @@ func projects() []Project {
 	}()
 
 	wg.Wait()
+
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].Name < projects[j].Name
+	})
 
 	return projects
 }


### PR DESCRIPTION
Currently the result of `captain up <project>` is unpredictable because:
1. The lookup of the project is parallelized (order not guaranteed): https://github.com/jenssegers/captain/blob/822e02debb4c5da40ef9404ee0d1cc2f8bc7940c/main.go#L93-L96
2. The first match is chosen from the list: https://github.com/jenssegers/captain/blob/822e02debb4c5da40ef9404ee0d1cc2f8bc7940c/main.go#L140

I have two projects: `mysql` and `mysql-5.7`. Sometimes, when I run `captain up mysql`, it starts `mysql-5.7`. But it's easier to reproduce the inconsistency by running `captain ls`:
```
→ captain ls
sqlsrv
metrics
memcached
mysql
elasticsearch
azure-sql-edge
postgres
mysql-5.7
mariadb
redis
grafana
ibm-db2

→ captain ls
sqlsrv
mysql-5.7
redis
mysql
oracle
memcached
postgres
azure-sql-edge
elasticsearch
mariadb
grafana
metrics
```
Sorting projects makes the `ls` output predictable and should fix the `up` command as well.

---

The second commit should address https://github.com/jenssegers/captain/issues/20. What's happening is that in most cases the list of projects scanned by the `projects()` function is incomplete. It happens because `projects()` only waits for all `scan()` goroutines to complete but doesn't wait for all results to be read from the channel.