### PR TITLE
Ignore SIGINT when running docker-compose

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -146,7 +147,12 @@ func dc(project Project, arg ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	signal.Ignore(os.Interrupt)
+	defer signal.Reset(os.Interrupt)
+	return cmd.Wait()
 }
 
 func search(pattern string) (Project, error) {


### PR DESCRIPTION
Steps to reproduce:
1. Start a project via `captain up`.
2. Stop it via Ctrl+C

Depending on how lucky you are, the shell prompt may get messed up because `captain` will exit immediately while `docker-compose` running the project services will keep writing to the terminal and will exit only when all services exit.

For example, below, the "ignore-sigint)" on the third line is the shell prompt and there's nothing after "canceled":
```
postgres-postgres-1  | 2022-10-22 04:55:18.526 UTC [1] LOG:  database system is ready to accept connections
^CGracefully stopping... (press Ctrl+C again to force)
[+] Running 1/1ignore-sigint)
 ⠿ Container postgres-postgres-1  Stopped                                                              0.1s
canceled
```
The service has stopped but it looks like it's still running (the prompt is overwritten by the container output).

This could be mitigated if Captain ignored SIGINT while `docker-compose` is running. The shell will send SIGINT to `docker-compose` automatically as part of the process group, so `docker-compose` will exit as soon as it can and Captain will exit right after that.