### PR TITLE
Use 'git describe --tags' to set version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services:
     - docker
 
 script:
+    - export VERSION=$(git describe --tags)
+    - sed -i "s/CAPTAIN_VERSION/${VERSION}/" main.go
     - make build
 
 deploy:

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "captain"
 	app.Usage = "Start and stop docker compose projects"
-	app.Version = "0.3.2"
+	app.Version = "CAPTAIN_VERSION"
 
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
`git describe --tags` will find the last tag in the commit history. If the current commit is a tag it will use the name of the tag. If not, it will use the name of the latest tag and append the number of commits and the shortened hash of the latest commit, e.g. '0.3.3-11-g2c923a3' where

- 0.3.3 is the name of the latest tag,
- 11 commits have been added on top and
- 2c923a3 is the hash of the latest commit.

This fixes #15.